### PR TITLE
node.bound correction in impl-JuMP.jl

### DIFF
--- a/src/impl-JuMP.jl
+++ b/src/impl-JuMP.jl
@@ -69,9 +69,9 @@ function bound!(node::JuMPNode)
             node.solution[v] = JuMP.value(v)
         end
     elseif node.solution_status in [MOI.INFEASIBLE,MOI.LOCALLY_INFEASIBLE]
-        node.bound = -Inf
-    elseif node.solution_status == MOI.DUAL_INFEASIBLE
         node.bound = Inf
+    elseif node.solution_status == MOI.DUAL_INFEASIBLE
+        node.bound = -Inf
     else
         @warn "Unexpected node solution status: $(node.solution_status)"
         node.bound = -Inf


### PR DESCRIPTION
For minimization problems, an infeasible relaxation would give a bound of `+Inf` and an unbounded relaxation would give a bound of `-Inf`.